### PR TITLE
Update LinkedIn scraper to wait for presence of grid elements

### DIFF
--- a/linkedin_scraper/company.py
+++ b/linkedin_scraper/company.py
@@ -128,7 +128,7 @@ class Company(Scraper):
             pass
         driver.get(os.path.join(self.linkedin_url, "people"))
 
-        _ = WebDriverWait(driver, 3).until(EC.presence_of_all_elements_located((By.XPATH, '//span[@dir="ltr"]')))
+        _ = WebDriverWait(driver, 3).until(EC.presence_of_all_elements_located((By.CSS_SELECTOR, 'div.scaffold-finite-scroll__content > ul > li.grid')))
 
         driver.execute_script("window.scrollTo(0, Math.ceil(document.body.scrollHeight/2));")
         time.sleep(1)


### PR DESCRIPTION
The current implementation of the "Company" component was consistently failing due to the WebDriverWait condition for the `//span[@dir="ltr"] ` element. This element has been removed from the webpage, causing the wait to time out.

To address this issue, I've introduced a new WebDriverWait condition using a CSS selector: `div.scaffold-finite-scroll__content > ul > li.grid`. This selector accurately targets the desired element on the page, ensuring that the component waits for the correct element to be present before proceeding.

Changes:
- Added: New WebDriverWait condition using a CSS selector.
- Removed: Outdated WebDriverWait condition for the //span[@dir="ltr"] element.